### PR TITLE
fix: Allow importing quantities in Quickstatements

### DIFF
--- a/build/QuickStatements/config.json
+++ b/build/QuickStatements/config.json
@@ -15,6 +15,7 @@
 			"server": "${WB_PUBLIC_SCHEME_HOST_AND_PORT}",
 			"api": "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/w/api.php",
 			"pageBase": "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/wiki/",
+			"entityBase" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/entity/",
 			"toolBase": "${QS_PUBLIC_SCHEME_HOST_AND_PORT}/",
 			"types": {
 				"P": {

--- a/development/images/quickstatements/config.json
+++ b/development/images/quickstatements/config.json
@@ -15,6 +15,7 @@
 			"server": "${WIKIBASE_PUBLIC_URL}",
 			"api": "${WIKIBASE_PUBLIC_URL}/w/api.php",
 			"pageBase": "${WIKIBASE_PUBLIC_URL}/wiki/",
+			"entityBase": "${WIKIBASE_PUBLIC_URL}/entity/",
 			"toolBase": "${QUICKSTATEMENTS_PUBLIC_URL}/",
 			"types": {
 				"P": {

--- a/development/tests/quickstatements/quickstatements.spec.ts
+++ b/development/tests/quickstatements/quickstatements.spec.ts
@@ -186,6 +186,23 @@ describe( 'QuickStatements', function () {
 		).toEqual( 'Will it blend?' );
 	} );
 
+	it( 'Should be able to add a quantity with a unit', async function () {
+		const itemId = await WikibaseApi.createItem( 'quantity-item', {} );
+		const unitId = await WikibaseApi.createItem( 'quantity-unit', {} );
+		const quantityPropertyId = await WikibaseApi.getProperty( 'quantity' );
+		const unitNumber = unitId.replace( 'Q', '' );
+
+		await browser.executeQuickStatement(
+			`${ itemId }|${ quantityPropertyId }|5U${ unitNumber }`
+		);
+
+		const responseData = await SpecialEntityDataPage.getData( itemId );
+		expect(
+			responseData.entities[ itemId ].claims[ quantityPropertyId ][ 0 ].mainsnak
+				.datavalue.value.unit
+		).toEqual( `${ testEnv.vars.WIKIBASE_URL }/entity/${ unitId }` );
+	} );
+
 	describe( 'Should be able to add qualifiers to statements with a range of datatypes', function () {
 		// should be disabled for dynamic tests
 		mainSnakDataTypes.forEach( ( mainSnakDataType ) => {


### PR DESCRIPTION
The property _entityBase_ needs to be added in order to import quantities with Quickstatements.