### PR TITLE
[Parity] Bundle additional optional extensions and enable Redis support

### DIFF
--- a/development/images/wikibase/Dockerfile
+++ b/development/images/wikibase/Dockerfile
@@ -52,9 +52,9 @@ RUN savedAptMark="$(apt-mark showmanual)"; \
         opcache \
         ; \
     \
-    pecl install APCu-5.1.21; \
+    pecl install APCu-5.1.21 redis-6.3.0; \
         docker-php-ext-enable \
-        apcu \
+        apcu redis \
         ; \
     rm -r /tmp/pear; \
     \

--- a/development/images/wikibase/Dockerfile
+++ b/development/images/wikibase/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update; \
         gettext-base \
         librsvg2-bin \
         imagemagick \
+        # Required by Score MediaWiki Extension
+        lilypond \
         # Required by SyntaxHighlighting MediaWiki Extension
         python3 \
         # Required by Scribunto MediaWiki Extension

--- a/development/images/wikibase/README.md
+++ b/development/images/wikibase/README.md
@@ -66,6 +66,8 @@ must be set explicitly.
 | `WIKIMEDIA_OAUTH_CONSUMER_TOKEN` | | Consumer token from a Wikimedia OAuth 1.0a consumer. Wikimedia login is active only when this and the secret token below are provided.                                                    |
 | `WIKIMEDIA_OAUTH_SECRET_TOKEN` | | Secret token from that consumer.                                                                                                                                                            |
 | `QUICKSTATEMENTS_PUBLIC_URL` |         | Public URL of the QuickStatements server, such as [wikibase/quickstatements](https://hub.docker.com/r/wikibase/quickstatements). Initial setup also uses it to create the OAuth consumer; changing it later does not update that consumer. |
+| `REDIS_SERVER`               |         | Redis server address. Enables Redis for the main cache and session store when using the default WBS configuration. |
+| `REDIS_PASSWORD`             |         | Password for a protected Redis server. |
 
 ## Features
 

--- a/development/images/wikibase/README.md
+++ b/development/images/wikibase/README.md
@@ -78,19 +78,37 @@ extensions and additional packages placed in this image.
 
 | Bundled extension | Enabled | Description |
 | --- | --- | --- |
+| [AdvancedSearch](https://www.mediawiki.org/wiki/Extension:AdvancedSearch) | No | Adds an advanced search interface. |
 | [Babel](https://www.mediawiki.org/wiki/Extension:Babel) | Yes | Adds a parser function to inform other users about language proficiency and categorize users of the same levels and languages. |
 | [CLDR](https://www.mediawiki.org/wiki/Extension:CLDR) | Yes | Provides functions to localize the names of languages, countries, currencies, and time units based on their language code. |
-| [DiscussionTools](https://www.mediawiki.org/wiki/Extension:DiscussionTools) | Yes | Adds modern discussion features such as reply links and add-topic workflows on talk pages. |
+| [CodeMirror](https://www.mediawiki.org/wiki/Extension:CodeMirror) | No | Adds an in-browser code editor. |
+| [ConfirmAccount](https://www.mediawiki.org/wiki/Extension:ConfirmAccount) | No | Lets administrators review and approve account requests. |
+| [DeleteBatch](https://www.mediawiki.org/wiki/Extension:DeleteBatch) | No | Lets administrators delete many pages at once. |
 | [Elastica](https://www.mediawiki.org/wiki/Extension:Elastica), [CirrusSearch](https://www.mediawiki.org/wiki/Extension:CirrusSearch), and [WikibaseCirrusSearch](https://www.mediawiki.org/wiki/Extension:WikibaseCirrusSearch) | Yes | Provide OpenSearch integration for MediaWiki and Wikibase. Enabled when `ELASTICSEARCH_HOST` is set. See the [CirrusSearch documentation](https://www.mediawiki.org/wiki/Extension:CirrusSearch) for index maintenance and reindexing. |
-| [Echo](https://www.mediawiki.org/wiki/Extension:Echo) | Yes | Provides notifications for user mentions, page activity, and other wiki events. |
+| [EmbedVideo](https://www.mediawiki.org/wiki/Extension:EmbedVideo) | No | Embeds supported video services in wiki pages. |
 | [EntitySchema](https://www.mediawiki.org/wiki/Extension:EntitySchema) | Yes | Stores Shape Expressions schemas on wiki pages. |
+| [InviteSignup](https://www.mediawiki.org/wiki/Extension:InviteSignup) | No | Restricts account creation to invitations issued by authorized users. |
+| [JsonConfig](https://www.mediawiki.org/wiki/Extension:JsonConfig) | No | Stores JSON configuration pages in a dedicated content model. |
+| [Kartographer](https://www.mediawiki.org/wiki/Extension:Kartographer) | No | Adds interactive maps. Requires a compatible map-tile server. |
+| [Mailgun](https://www.mediawiki.org/wiki/Extension:Mailgun) | No | Sends MediaWiki email through the Mailgun API. |
+| [MobileFrontend](https://www.mediawiki.org/wiki/Extension:MobileFrontend) | No | Adapts the wiki interface for mobile devices. |
 | [OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) | Yes | Allows users to safely authorize another application (a “consumer”) to use the MediaWiki Action API on their behalf. |
 | [PluggableAuth](https://www.mediawiki.org/wiki/Extension:PluggableAuth) and [WSOAuth](https://www.mediawiki.org/wiki/Extension:WSOAuth) | Yes | Let users authenticate to Wikibase with their Wikimedia account through a Meta-Wiki OAuth 1.0a consumer. Enabled when both Wikimedia OAuth token variables are set. |
+| [RevisionSlider](https://www.mediawiki.org/wiki/Extension:RevisionSlider) | No | Adds a visual revision comparison slider. |
+| [Score](https://www.mediawiki.org/wiki/Extension:Score) | No | Adds musical notation rendering and its Wikibase data type. |
+| [StopForumSpam](https://www.mediawiki.org/wiki/Extension:StopForumSpam) | No | Checks account registrations against the Stop Forum Spam service. |
+| [TemplateSandbox](https://www.mediawiki.org/wiki/Extension:TemplateSandbox) | No | Lets editors preview pages using draft template revisions. |
+| [ThatSrc](https://github.com/nyurik/ThatSrc) | No | Displays source information for embedded media. |
+| [TorBlock](https://www.mediawiki.org/wiki/Extension:TorBlock) | No | Restricts edits from anonymous Tor exit nodes. |
+| [TwoColConflict](https://www.mediawiki.org/wiki/Extension:TwoColConflict) | No | Provides a two-column edit-conflict interface. |
 | [UniversalLanguageSelector](https://www.mediawiki.org/wiki/Extension:UniversalLanguageSelector) | Yes | Allows users to select a language and configure its support. |
 | [WikibaseEdtf](https://github.com/ProfessionalWiki/WikibaseEdtf) | No | Adds support for the Extended Date/Time Format (EDTF) specification through a new data type. |
 | [WikibaseInWikitext](https://github.com/wbstack/mediawiki-extensions-WikibaseInWikitext) | Yes | Adds a `<sparql>` tag for writing local Query Service examples on wiki pages. |
+| [WikibaseLexeme](https://www.mediawiki.org/wiki/Wikibase/Lexeme) | No | Adds lexicographical data, forms, and senses to Wikibase. |
+| [WikibaseLexemeCirrusSearch](https://www.mediawiki.org/wiki/Extension:WikibaseLexemeCirrusSearch) | No | Adds OpenSearch support for lexemes when Wikibase Lexeme and Wikibase CirrusSearch are enabled. |
 | [WikibaseLocalMedia](https://github.com/ProfessionalWiki/WikibaseLocalMedia) | Yes | Adds support for local media files to Wikibase through a new data type. |
 | [WikibaseManifest](https://www.mediawiki.org/wiki/Extension:WikibaseManifest) | Yes | Provides metadata about the structured data repository through an API. |
+| [WikiHiero](https://www.mediawiki.org/wiki/Extension:WikiHiero) | No | Adds support for Ancient Egyptian hieroglyphs. |
 
 Enable and configure additional packaged extensions in `LocalSettings.php`
 using the normal MediaWiki instructions for that extension. A complete

--- a/development/images/wikibase/build/extensions.json
+++ b/development/images/wikibase/build/extensions.json
@@ -128,6 +128,166 @@
       }
     },
     {
+      "name": "ConfirmAccount",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/ConfirmAccount",
+        "ref": "refs/heads/REL1_46",
+        "commit": "a3227fdc9413ec8c3b50d671ee389a72d818257b"
+      }
+    },
+    {
+      "name": "InviteSignup",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/InviteSignup",
+        "ref": "refs/heads/REL1_46",
+        "commit": "07463e8d97370a36bc8ef47153c818ef9e3b7cd3"
+      }
+    },
+    {
+      "name": "Mailgun",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/Mailgun",
+        "ref": "refs/heads/REL1_46",
+        "commit": "fd8d7748ccee5e89d5d2c0502efa6abefbeedfd4"
+      }
+    },
+    {
+      "name": "StopForumSpam",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/StopForumSpam",
+        "ref": "refs/heads/REL1_46",
+        "commit": "b133d7b9f3822b217d0b396359aa931e5a7497d3"
+      }
+    },
+    {
+      "name": "TorBlock",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/TorBlock",
+        "ref": "refs/heads/REL1_46",
+        "commit": "7a34e88517b1bd70856b299aec7563eb9091606b"
+      }
+    },
+    {
+      "name": "RevisionSlider",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/RevisionSlider",
+        "ref": "refs/heads/REL1_46",
+        "commit": "bcf88506161d57001b523bf9c2ff3a03cf565255"
+      }
+    },
+    {
+      "name": "JsonConfig",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/JsonConfig",
+        "ref": "refs/heads/REL1_46",
+        "commit": "f9015ed89d7aedeb6c5d18fed6b58bb598a7dc20"
+      }
+    },
+    {
+      "name": "WikiHiero",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/wikihiero",
+        "ref": "refs/heads/REL1_46",
+        "commit": "86214543cb98e467a54857cdca52d99203479fdf"
+      }
+    },
+    {
+      "name": "Score",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/Score",
+        "ref": "refs/heads/REL1_46",
+        "commit": "66a5309da42cc1956f76095816dacab7384bc021"
+      }
+    },
+    {
+      "name": "Kartographer",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/Kartographer",
+        "ref": "refs/heads/REL1_46",
+        "commit": "634b552f6f5d3c47dd9413dde00d81e0efcb4c81"
+      }
+    },
+    {
+      "name": "DeleteBatch",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/DeleteBatch",
+        "ref": "refs/heads/REL1_46",
+        "commit": "3e63873a3548b575a1decfe4914d09e3c3c009d8"
+      }
+    },
+    {
+      "name": "EmbedVideo",
+      "source": {
+        "repo": "https://github.com/StarCitizenWiki/mediawiki-extensions-EmbedVideo.git",
+        "ref": "refs/heads/master",
+        "commit": "d0aa2a3245c1308362b2ce77df1f6bb3e2bf6579"
+      }
+    },
+    {
+      "name": "ThatSrc",
+      "source": {
+        "repo": "https://github.com/nyurik/ThatSrc.git",
+        "ref": "refs/heads/master",
+        "commit": "3e039311504eb82f8c5c488a457b9e376b5cf7e3"
+      }
+    },
+    {
+      "name": "TemplateSandbox",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/TemplateSandbox",
+        "ref": "refs/heads/REL1_46",
+        "commit": "7fd76b37e6d85418ff082ab8127cf1c51c7fa466"
+      }
+    },
+    {
+      "name": "CodeMirror",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/CodeMirror",
+        "ref": "refs/heads/REL1_46",
+        "commit": "31801f4f592c30786a8845b4503855860b41be81"
+      }
+    },
+    {
+      "name": "AdvancedSearch",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/AdvancedSearch",
+        "ref": "refs/heads/REL1_46",
+        "commit": "23ae0b9718b368673ac86fbc86d0c701a54b48fa"
+      }
+    },
+    {
+      "name": "TwoColConflict",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/TwoColConflict",
+        "ref": "refs/heads/REL1_46",
+        "commit": "d4c4742626c2bec7720b5552c1e8d853fdc37f71"
+      }
+    },
+    {
+      "name": "MobileFrontend",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/MobileFrontend",
+        "ref": "refs/heads/REL1_46",
+        "commit": "e00881d4d6f2e91f57026e8fa81a7dd8ad71cda4"
+      }
+    },
+    {
+      "name": "WikibaseLexeme",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/WikibaseLexeme",
+        "ref": "refs/heads/REL1_46",
+        "commit": "f71760e895a3b0793a946f976bd5783409f87536"
+      }
+    },
+    {
+      "name": "WikibaseLexemeCirrusSearch",
+      "source": {
+        "repo": "https://gerrit.wikimedia.org/r/mediawiki/extensions/WikibaseLexemeCirrusSearch",
+        "ref": "refs/heads/REL1_46",
+        "commit": "3fbbbe32baac83146a1ff3f939e2631dc12de708"
+      }
+    },
+    {
       "name": "WikibaseSuite",
       "source": {
         "path": "runtime/var/www/html/extensions/WikibaseSuite"

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/DefaultSettings.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/DefaultSettings.php
@@ -27,6 +27,26 @@ $wgMainCacheType = CACHE_ACCEL;
 $wgSessionCacheType = CACHE_DB;
 $wgParserCacheType = CACHE_DB;
 $wgMemCachedServers = [];
+
+# Redis is optional. When configured, it provides a shared main cache and
+# session store suitable for multiple web or job-runner containers.
+$wbsRedisServer = getenv( 'REDIS_SERVER' );
+if ( $wbsRedisServer !== false && trim( (string)$wbsRedisServer ) !== '' ) {
+	$wbsRedisOptions = [
+		'class' => RedisBagOStuff::class,
+		'servers' => [ trim( (string)$wbsRedisServer ) ],
+		'connectTimeout' => 1,
+		'persistent' => true,
+	];
+	$wbsRedisPassword = getenv( 'REDIS_PASSWORD' );
+	if ( $wbsRedisPassword !== false && $wbsRedisPassword !== '' ) {
+		$wbsRedisOptions['password'] = $wbsRedisPassword;
+	}
+	$wgObjectCaches['redis'] = $wbsRedisOptions;
+	$wgMainCacheType = 'redis';
+	$wgSessionCacheType = 'redis';
+}
+
 $wgUseImageMagick = true;
 
 $wgRightsPage = '';

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/LoadExtensions.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/LoadExtensions.php
@@ -2,7 +2,8 @@
 
 # Image-owned default extension configuration. Simple extensions use MediaWiki's
 # standard loader; extension profiles group image-specific configuration and
-# conditional or multi-extension setup.
+# conditional or multi-extension setup. Optional profiles are available for
+# inclusion from /config/LocalSettings.php but do not change WBS defaults.
 
 $extensionProfilesPath = __DIR__ . '/extension-profiles';
 $openSearchEnabled = isset( $elasticsearchHost );

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/ConfirmAccount.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/ConfirmAccount.php
@@ -1,0 +1,37 @@
+<?php
+
+// Account-request policy used by Wikibase Cloud. It is intentionally optional:
+// enabling ConfirmAccount changes the public account-creation flow.
+wfLoadExtension( 'ConfirmAccount' );
+
+$wgMakeUserPageFromBio = false;
+$wgAutoWelcomeNewUsers = false;
+$wgConfirmAccountCaptchas = true;
+$wgConfirmAccountRequestFormItems = [
+	'UserName' => [ 'enabled' => true ],
+	'RealName' => [ 'enabled' => false ],
+	'Biography' => [ 'enabled' => false, 'minWords' => 50 ],
+	'AreasOfInterest' => [ 'enabled' => false ],
+	'CV' => [ 'enabled' => false ],
+	'Notes' => [ 'enabled' => true ],
+	'Links' => [ 'enabled' => false ],
+	'TermsOfService' => [ 'enabled' => false ],
+];
+
+$wgGroupPermissions['bureaucrat']['confirmaccount-notify'] = true;
+$wgGroupPermissions['bureaucrat']['requestips'] = false;
+$wgGroupPermissions['bureaucrat']['lookupcredentials'] = false;
+$wgGroupPermissions['*']['requestips'] = false;
+$wgGroupPermissions['*']['lookupcredentials'] = false;
+$wgGroupPermissions['*']['createaccount'] = false;
+$wgGroupPermissions['bureaucrat']['createaccount'] = true;
+
+$wgHooks['SkinTemplateNavigation::Universal'][] = static function ( $skin, array &$links ): bool {
+	if ( isset( $links['user-menu']['login'] ) || isset( $links['user-menu']['anonlogin'] ) ) {
+		$links['user-menu']['createaccount'] = [
+			'text' => wfMessage( 'requestaccount' )->text(),
+			'href' => SpecialPage::getTitleFor( 'RequestAccount' )->getFullURL(),
+		];
+	}
+	return true;
+};

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/InviteSignup.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/InviteSignup.php
@@ -1,0 +1,10 @@
+<?php
+
+// Invitation-only account creation is independent from ConfirmAccount and can
+// be selected on its own.
+wfLoadExtension( 'InviteSignup' );
+
+$wgGroupPermissions['*']['createaccount'] = false;
+$wgGroupPermissions['user']['createaccount'] = false;
+$wgGroupPermissions['sysop']['invitesignup'] = true;
+$wgISGroups = [ 'confirmed' ];

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/MobileFrontend.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/MobileFrontend.php
@@ -1,0 +1,6 @@
+<?php
+
+// MinervaNeue is bundled with MediaWiki and supplies MobileFrontend's default
+// skin in the WBS and Cloud configurations.
+wfLoadExtension( 'MobileFrontend' );
+$wgMFDefaultSkinClass = 'SkinMinerva';

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/Score.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/Score.php
@@ -1,0 +1,5 @@
+<?php
+
+// Enable Score's Wikibase data type when musical notation is selected.
+wfLoadExtension( 'Score' );
+$wgMusicalNotationEnableWikibaseDataType = true;

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/SpamBlacklist.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/SpamBlacklist.php
@@ -1,0 +1,20 @@
+<?php
+
+// Shared anti-spam sources used by Wikibase Cloud. The optional DNS blacklist
+// policy remains separate because it depends on deployment-specific networking.
+wfLoadExtension( 'SpamBlacklist' );
+
+$wgBlacklistSettings = [
+	'spam' => [
+		'files' => [
+			'https://meta.wikimedia.org/w/index.php?title=Spam_blacklist&action=raw&sb_ver=1',
+			'https://en.wikipedia.org/w/index.php?title=MediaWiki:Spam-blacklist&action=raw&sb_ver=1',
+			'https://raw.githubusercontent.com/wbstack/mediawiki-spam-lists/main/spam_list',
+		],
+	],
+	'email' => [
+		'files' => [
+			'https://raw.githubusercontent.com/wbstack/mediawiki-spam-lists/main/email_list',
+		],
+	],
+];

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/StopForumSpam.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/StopForumSpam.php
@@ -1,0 +1,4 @@
+<?php
+
+// StopForumSpam is an opt-in external anti-abuse service.
+wfLoadExtension( 'StopForumSpam' );

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/TwoColConflict.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/TwoColConflict.php
@@ -1,0 +1,4 @@
+<?php
+
+wfLoadExtension( 'TwoColConflict' );
+$wgTwoColConflictBetaFeature = false;

--- a/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/WikibaseLexeme.php
+++ b/development/images/wikibase/runtime/var/www/html/extensions/WikibaseSuite/config/extension-profiles/WikibaseLexeme.php
@@ -1,0 +1,15 @@
+<?php
+
+// Lexemes are an optional Wikibase capability. When the WBS OpenSearch profile
+// has loaded Wikibase search, also enable the matching Lexeme search support.
+wfLoadExtension( 'WikibaseLexeme' );
+$wgLexemeEnableDataTransclusion = true;
+
+if ( ExtensionRegistry::getInstance()->isLoaded( 'WikibaseCirrusSearch' ) ) {
+	wfLoadExtension( 'WikibaseLexemeCirrusSearch' );
+	$wgLexemeUseCirrus = true;
+	$wgContentNamespaces[] = 146;
+	$wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-lexeme';
+	$wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-form';
+	$wgWBRepoSettings['searchIndexTypes'][] = 'wikibase-sense';
+}


### PR DESCRIPTION
Bundles additional optional MediaWiki extensions and adds optional Redis support to the Wikibase image.

The extensions remain disabled by default, and Redis is used only when configured. The AMD64 image is approximately 8.3 MiB (1.37%) larger than before these changes. The default WBS configuration has no runtime behavior change—this adds capabilities for deployments that choose to use them. The additional bundled extensions are listed in the Wikibase image README.