### PR TITLE
fix(wikibase): retain extension install cache for local source changes

### DIFF
--- a/development/images/wikibase/Dockerfile
+++ b/development/images/wikibase/Dockerfile
@@ -107,10 +107,9 @@ USER nobody
 COPY --chown=nobody:nogroup --chmod=755 build/extensions.json /tmp/extensions.json
 COPY --chown=nobody:nogroup --chmod=755 build/InstallExtensions.php /tmp/InstallExtensions.php
 COPY --chown=nobody:nogroup --chmod=755 build/patches /tmp/patches
-COPY --chown=nobody:nogroup --chmod=755 runtime/var/www/html/extensions /tmp/wbs-local-sources/runtime/var/www/html/extensions
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-RUN php /tmp/InstallExtensions.php /tmp/extensions.json /tmp/wbs-local-sources && \
+RUN php /tmp/InstallExtensions.php /tmp/extensions.json && \
     rm -rf composer.lock && \
     composer update --no-dev -vv -n
 


### PR DESCRIPTION
## Summary
- keep local extension source changes out of the remote extension installation and Composer layer
- retain the final runtime copy that supplies local extensions to the completed Wikibase image

## Testing
- development/wbs-dev build wikibase
- development/wbs-dev lint